### PR TITLE
Improve dashboard UX with loading states and autosave

### DIFF
--- a/docs/dashboard-ux-review.md
+++ b/docs/dashboard-ux-review.md
@@ -1,0 +1,74 @@
+# Revisão UX/UI do Dashboard Baileys API
+
+## Visão geral
+
+O dashboard atual é construído com HTML estático (`public/index.html`) estilizado via Tailwind CDN e JavaScript vanilla (`public/dashboard.js`) que consome os endpoints REST expostos pelo backend Express. A interface se apoia em atualizações por polling a cada 3 segundos para manter métricas e estados das instâncias sincronizados.
+
+## Etapas da jornada e dependências
+
+### Etapa 1 — Boot do dashboard e carregamento inicial
+- **Comportamento**: `initChart()` inicializa o gráfico de métricas (Chart.js) e `refreshInstances()` é chamado imediatamente e em intervalo de 3s (`setInterval`).
+- **Dependências técnicas**: `Chart.js` via CDN, endpoint `GET /instances`, armazenamento local `localStorage` para chave API e range de métricas.
+- **Observações**: Estado do badge de status é atualizado com base na resposta da instância selecionada.
+
+### Etapa 2 — Seleção e gerenciamento de instâncias
+- **Comportamento**: A lista de instâncias popula `<select id="selInstance">` e gera cards dinâmicos com estatísticas. Ações inline permitem editar nome/notas, selecionar, carregar QR, logout, wipe e exclusão (com modal).
+- **Dependências técnicas**: Endpoints `GET/POST/PATCH/DELETE /instances`, componentes HTML gerados dinamicamente, `fetchJSON()` para chamadas autenticadas, modal `#modalDelete`.
+- **Observações**: Cards refletem contadores por status (1–5) e uso de rate limit.
+
+### Etapa 3 — Contexto da instância e notas
+- **Comportamento**: Ao selecionar uma instância, o bloco "Contexto da instância" é exibido com textarea sincronizada e metadados de criação/atualização (`metadata.createdAt`, `metadata.updatedAt`).
+- **Dependências técnicas**: Endpoint `GET /instances/:id`, propriedades `note/notes`, elementos `#noteCard`, `#instanceNote`, `#noteMeta`.
+- **Observações**: Persistência depende de ação manual "Salvar" no card correspondente.
+
+### Etapa 4 — Métricas e gráfico de timeline
+- **Comportamento**: KPIs e gráfico de linha atualizam com dados de `/instances/:id/metrics`. Filtro `#selRange` determina janela em minutos armazenada em `localStorage`.
+- **Dependências técnicas**: Endpoint `GET /instances/:id/metrics`, estrutura `metrics.counters`, `metrics.rate`, `metrics.ack`, timeline com campos `sent`, `pending`, `serverAck`, `delivered`, `read`, `played`.
+- **Observações**: Falta fallback visual além de texto quando não há dados; atualizações dependem do polling global.
+
+### Etapa 5 — Ações de sessão e QR Code
+- **Comportamento**: Área de QR mostra imagem carregada via `/instances/:id/qr.png` quando desconectada. Botões executam `logout`, `wipe` e `pair` (gera código de pareamento copiado para clipboard).
+- **Dependências técnicas**: Endpoints `/instances/:id/qr.png`, `/instances/:id/logout`, `/instances/:id/wipe`, `/instances/:id/pair`, uso de API Key (`x-api-key`) e manipulação de `navigator.clipboard`.
+- **Observações**: Feedback textual em `#qrHint`; ausência de estados carregando/erro visuais além de texto.
+
+### Etapa 6 — Envio rápido
+- **Comportamento**: Formulário "Envio Rápido" solicita API Key, telefone e mensagem, envia `POST /instances/:id/send-text` e exibe JSON de resposta em `#sendOut`.
+- **Dependências técnicas**: Endpoint `/instances/:id/send-text`, validações mínimas (campos vazios), armazenamento de API Key no `localStorage`.
+- **Observações**: Não há máscara/validação de formato ou feedback contextual (ex: sucesso/erro inline estilizado).
+
+## Recomendações de melhorias referenciadas
+
+1. **Otimizar boot e sincronização (Etapa 1)**
+   - Introduzir estados de carregamento/skeleton enquanto `refreshInstances()` aguarda resposta para evitar flash de conteúdo vazio.
+   - Reduzir polling agressivo (3s) adotando WebSockets/SSE quando disponíveis ou expondo controle manual de refresh para ambientes com muitas instâncias.
+
+2. **Refinar cards e listagem de instâncias (Etapa 2)**
+   - Reorganizar layout dos cards usando grid responsivo com hierarquia visual clara (nome + status destacado, KPIs em colunas consistentes).
+   - Adicionar filtros/pesquisa e ordenação (ex: instâncias desconectadas primeiro) para facilitar operação com dezenas de instâncias.
+   - Mostrar feedback instantâneo (toast ou badge temporário) ao salvar nome/notas sem depender apenas do badge global.
+
+3. **Melhorar edição de notas (Etapa 3)**
+   - Implementar autosave com debounce no textarea, evitando exigir clique em "Salvar" para notas rápidas.
+   - Exibir histórico de alterações ou pelo menos timestamp relativo (ex: "Atualizado há 5 min") para reforçar contexto temporal.
+
+4. **Aprimorar experiência de métricas (Etapa 4)**
+   - Incluir indicadores de carregamento e fallback gráfico (ex: placeholder chart) quando não houver dados.
+   - Implementar tooltips personalizados descrevendo cada série e cor, e legendas acessíveis (contraste AA) para status 1–5.
+   - Permitir exportar dados da timeline (CSV/JSON) e adicionar agregações como taxa de entrega média dentro do range selecionado.
+
+5. **Feedback e estados para ações de sessão (Etapa 5)**
+   - Adicionar estados "Carregando" nos botões (com spinners/desabilitados) enquanto requisições `logout/wipe/pair` estão em andamento.
+   - Mostrar QR em contêiner com borda indicando status (ex: vermelho quando expirado), e incluir contador de expiração quando possível.
+   - Para `pair`, exibir modal com código e botão de copiar em vez de texto plano no hint, garantindo acessibilidade mobile.
+
+6. **Formulário de envio rápido mais robusto (Etapa 6)**
+   - Validar formato E.164 com feedback inline, incluir máscara opcional e permitir mensagens multiline com contador de caracteres.
+   - Destacar claramente sucesso/erro com cartões coloridos e histórico dos últimos envios (dependendo de `/instances/:id/send-text`).
+   - Permitir seleção de templates/mensagens pré-definidas e anexos simples, aproveitando endpoints existentes ou futuros.
+
+7. **Melhorias transversais**
+   - Consolidar componentes de badge e botões em um micro design system (classes utilitárias reutilizáveis) para consistência.
+   - Aumentar acessibilidade: atributos `aria-live` para feedbacks, foco visível, contraste ajustado (especialmente textos em cards e badges).
+   - Documentar fluxos e dependências no README para alinhar onboarding de novos usuários e desenvolvedores front-end.
+
+Estas recomendações, alinhadas às etapas mapeadas, fortalecem a experiência operacional do dashboard, reduzem fricções e criam base para evoluções futuras sem alterar drasticamente a infraestrutura existente.

--- a/public/index.html
+++ b/public/index.html
@@ -11,12 +11,17 @@
   <div class="max-w-6xl mx-auto p-6 space-y-6">
     <header class="flex items-center justify-between">
       <h1 class="text-2xl font-bold">Baileys API — Dashboard</h1>
-      <span id="badge" class="px-3 py-1 rounded-full text-sm bg-slate-200">—</span>
+      <span id="badge" class="px-3 py-1 rounded-full text-sm bg-slate-200" aria-live="polite">—</span>
     </header>
 
     <section class="p-4 bg-white rounded-2xl shadow">
       <div class="flex items-center gap-3 flex-wrap">
-        <select id="selInstance" class="border rounded-lg px-3 py-2"></select>
+        <div class="relative">
+          <select id="selInstance" class="border rounded-lg px-3 py-2 pr-10 min-w-[16rem]"></select>
+          <div id="instanceLoading" class="hidden absolute inset-y-0 right-2 flex items-center" aria-hidden="true">
+            <span class="h-4 w-4 border-2 border-slate-300 border-t-slate-500 rounded-full animate-spin"></span>
+          </div>
+        </div>
         <button id="btnNew" class="px-3 py-2 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg">+ Nova instância</button>
         <span class="text-sm text-slate-500">Sessões em: <code id="sessionsRoot"></code></span>
       </div>
@@ -25,7 +30,13 @@
           <p class="text-xs font-semibold uppercase tracking-wide text-sky-700">Contexto da instância</p>
           <span id="noteMeta" class="text-xs text-slate-500"></span>
         </div>
-        <textarea id="instanceNote" rows="3" class="w-full border rounded-lg p-2 text-sm" placeholder="Anotações sobre esta instância..."></textarea>
+        <div class="space-y-2">
+          <textarea id="instanceNote" rows="3" class="w-full border rounded-lg p-2 text-sm" placeholder="Anotações sobre esta instância..."></textarea>
+          <div class="flex items-center justify-between text-[11px] text-slate-500">
+            <span id="noteStatus" aria-live="polite"></span>
+            <button id="noteRetry" class="hidden text-sky-600 hover:underline" type="button">Tentar novamente</button>
+          </div>
+        </div>
       </div>
     </section>
 
@@ -66,21 +77,53 @@
       </div>
 
       <div class="relative w-full h-64 md:h-80 xl:h-96 overflow-hidden">
+        <div id="metricsSkeleton" class="absolute inset-0 flex items-center justify-center bg-white/80 hidden">
+          <div class="flex flex-col items-center gap-2 text-sm text-slate-500">
+            <span class="h-6 w-6 border-2 border-slate-300 border-t-slate-500 rounded-full animate-spin"></span>
+            <span>Carregando métricas…</span>
+          </div>
+        </div>
         <canvas id="metricsChart" class="absolute inset-0 w-full h-full"></canvas>
       </div>
-      <p id="chartHint" class=
-
-class="text-xs text-slate-500">Nenhum dado disponível ainda.</p>
+      <p id="chartHint" class="text-xs text-slate-500" aria-live="polite">Nenhum dado disponível ainda.</p>
     </section>
 
-    <section id="cards" class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4"></section>
+    <section class="space-y-4">
+      <div id="cardsSkeleton" class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div class="p-4 bg-white rounded-2xl shadow space-y-3 animate-pulse">
+          <div class="h-4 bg-slate-200 rounded w-1/2"></div>
+          <div class="h-3 bg-slate-100 rounded w-1/3"></div>
+          <div class="grid grid-cols-3 gap-2">
+            <div class="h-16 bg-slate-100 rounded"></div>
+            <div class="h-16 bg-slate-100 rounded"></div>
+            <div class="h-16 bg-slate-100 rounded"></div>
+          </div>
+          <div class="h-20 bg-slate-100 rounded"></div>
+        </div>
+        <div class="p-4 bg-white rounded-2xl shadow space-y-3 animate-pulse hidden sm:block">
+          <div class="h-4 bg-slate-200 rounded w-1/2"></div>
+          <div class="h-3 bg-slate-100 rounded w-1/3"></div>
+          <div class="grid grid-cols-3 gap-2">
+            <div class="h-16 bg-slate-100 rounded"></div>
+            <div class="h-16 bg-slate-100 rounded"></div>
+            <div class="h-16 bg-slate-100 rounded"></div>
+          </div>
+          <div class="h-20 bg-slate-100 rounded"></div>
+        </div>
+      </div>
+      <section id="cards" class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4"></section>
+    </section>
 
     <section class="grid md:grid-cols-3 gap-6">
       <div class="p-4 bg-white rounded-2xl shadow">
         <h2 class="font-semibold mb-2">QR Code (instância selecionada)</h2>
-        <div id="qrWrap" class="border rounded-xl p-3 text-center">
+        <div id="qrWrap" class="border rounded-xl p-3 text-center transition-colors">
+          <div id="qrLoader" class="hidden flex flex-col items-center gap-2 text-sm text-slate-500">
+            <span class="h-6 w-6 border-2 border-slate-300 border-t-slate-500 rounded-full animate-spin"></span>
+            <span>Sincronizando QR…</span>
+          </div>
           <img id="qrImg" alt="QR" class="mx-auto hidden" />
-          <div id="qrHint" class="text-sm text-slate-500">Selecione uma instância desconectada para ver o QR.</div>
+          <div id="qrHint" class="text-sm text-slate-500" aria-live="polite">Selecione uma instância desconectada para ver o QR.</div>
         </div>
         <div class="mt-3 flex gap-2 flex-wrap">
           <button id="btnLogout" class="px-3 py-2 bg-amber-600 hover:bg-amber-700 text-white rounded-lg">Desconectar</button>
@@ -98,18 +141,21 @@ class="text-xs text-slate-500">Nenhum dado disponível ainda.</p>
           </div>
           <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
             <div>
-              <label class="block text-sm font-medium text-slate-700 mb-1">Telefone (55DDDNUMERO)</label>
-              <input id="inpPhone" type="text" class="w-full border rounded-lg px-3 py-2 text-sm" placeholder="5511999999999" />
+              <label class="block text-sm font-medium text-slate-700 mb-1">Telefone (E.164)</label>
+              <input id="inpPhone" type="tel" class="w-full border rounded-lg px-3 py-2 text-sm" placeholder="+5511999999999" />
             </div>
             <div>
               <label class="block text-sm font-medium text-slate-700 mb-1">Mensagem</label>
-              <input id="inpMsg" type="text" class="w-full border rounded-lg px-3 py-2 text-sm" placeholder="Sua mensagem aqui" />
+              <textarea id="inpMsg" rows="3" class="w-full border rounded-lg px-3 py-2 text-sm" placeholder="Sua mensagem aqui"></textarea>
+              <div class="mt-1 text-[11px] text-slate-500 text-right">
+                <span id="msgCounter">0</span>/4096
+              </div>
             </div>
           </div>
           <div class="flex gap-2">
             <button id="btnSend" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg">Enviar</button>
           </div>
-          <div id="sendOut" class="text-xs text-slate-600 bg-slate-50 rounded p-2 min-h-[2rem]"></div>
+          <div id="sendOut" class="text-xs text-slate-600 bg-slate-50 rounded p-2 min-h-[2rem]" aria-live="polite"></div>
         </div>
       </div>
     </section>
@@ -124,6 +170,23 @@ class="text-xs text-slate-500">Nenhum dado disponível ainda.</p>
         <div class="flex justify-end gap-2">
           <button data-act="modal-cancel" class="px-3 py-2 border rounded-lg">Cancelar</button>
           <button data-act="modal-confirm" class="px-3 py-2 bg-rose-600 hover:bg-rose-700 text-white rounded-lg">Excluir</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Modal de pareamento -->
+    <div id="pairModal" class="hidden fixed inset-0 bg-black/50 backdrop-blur-sm items-center justify-center z-40">
+      <div class="bg-white rounded-2xl shadow-xl max-w-md w-full mx-4 p-6 space-y-4">
+        <div class="space-y-1">
+          <h3 class="text-lg font-semibold">Código de pareamento gerado</h3>
+          <p class="text-sm text-slate-500">Use o código abaixo no aplicativo para conectar esta instância.</p>
+        </div>
+        <div class="flex items-center justify-between gap-4 bg-slate-50 rounded-xl px-4 py-3">
+          <code id="pairModalCode" class="text-lg font-semibold text-slate-900"></code>
+          <button id="pairModalCopy" class="px-3 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg">Copiar</button>
+        </div>
+        <div class="flex justify-end">
+          <button id="pairModalClose" class="px-3 py-2 border rounded-lg">Fechar</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add loading skeletons, aria-live feedback, and a pairing modal to the dashboard shell for clearer UX cues
- implement debounced autosave for instance notes, plus resilient refresh logic and QR state handling
- tighten quick send validation/feedback and introduce reusable UI helpers for busy states and messaging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbd8422a60833284cd1d3ef217f3d3