### PR TITLE
Configure Helmet CSP to allow CDN assets

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -22,7 +22,22 @@ const PUBLIC_DIR = path.resolve(process.cwd(), 'public');
 
 const app = express();
 app.disable('x-powered-by');
-app.use(helmet());
+
+const defaultCsp = helmet.contentSecurityPolicy.getDefaultDirectives();
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        ...defaultCsp,
+        'script-src': [
+          ...(defaultCsp['script-src'] ?? []),
+          'https://cdn.tailwindcss.com',
+          'https://cdn.jsdelivr.net',
+        ],
+      },
+    },
+  }),
+);
 app.use(cors());
 app.use(express.json({ limit: '1mb' }));
 app.use(express.static(PUBLIC_DIR));


### PR DESCRIPTION
## Summary
- configure Helmet with an explicit CSP that extends the defaults
- allow Tailwind and jsDelivr CDN scripts so the dashboard assets load

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbff63b8548332b6f5fc66cfc2ecfc