### PR TITLE
Align send timeout configuration across services

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npm start
 - `WEBHOOK_HMAC_SECRET`: Segredo opcional para assinar os eventos via HMAC
 - `RATE_MAX_SENDS`: Máximo de mensagens por janela de tempo (padrão: 20)
 - `RATE_WINDOW_MS`: Janela de tempo para rate limiting em ms (padrão: 15000)
-- `SEND_TIMEOUT_MS`: Timeout padrão para envios ativos (padrão: 25000)
+- `SEND_TIMEOUT_MS`: Timeout padrão para envios ativos, aplicado tanto às rotas HTTP quanto ao `MessageService` (padrão: 25000)
 - `POLL_STORE_TTL_MS`: Tempo de retenção das mensagens de enquete (padrão: 6h)
 - `POLL_FEEDBACK_TEMPLATE`: Template opcional para resposta automática após voto em enquete
 

--- a/src/baileys/messageService.ts
+++ b/src/baileys/messageService.ts
@@ -3,13 +3,12 @@ import type Long from 'long';
 import pino from 'pino';
 import { mapLeadFromMessage } from '../services/leadMapper.js';
 import { WebhookClient } from '../services/webhook.js';
+import { getSendTimeoutMs } from '../utils.js';
 
 export interface SendTextOptions {
   timeoutMs?: number;
   messageOptions?: Parameters<WASocket['sendMessage']>[2];
 }
-
-const DEFAULT_SEND_TIMEOUT_MS = Number(process.env.SEND_TIMEOUT_MS ?? 25_000);
 
 function extractMessageType(message: WAMessage): string | null {
   const keys = Object.keys(message.message || {});
@@ -63,7 +62,7 @@ export class MessageService {
   ) {}
 
   async sendText(jid: string, text: string, options: SendTextOptions = {}): Promise<WAMessage> {
-    const timeoutMs = options.timeoutMs ?? DEFAULT_SEND_TIMEOUT_MS;
+    const timeoutMs = options.timeoutMs ?? getSendTimeoutMs();
     const payload = { text } as const;
 
     const sendPromise = this.sock.sendMessage(jid, payload, options.messageOptions);

--- a/src/baileys/pollService.ts
+++ b/src/baileys/pollService.ts
@@ -9,6 +9,7 @@ import { getAggregateVotesInPollMessage } from '@whiskeysockets/baileys';
 import pino from 'pino';
 import { mapLeadFromMessage } from '../services/leadMapper.js';
 import { WebhookClient } from '../services/webhook.js';
+import { getSendTimeoutMs } from '../utils.js';
 import { PollMessageStore } from './store.js';
 import type { MessageService } from './messageService.js';
 
@@ -163,7 +164,7 @@ export class PollService {
     try {
       if (this.messageService) {
         await this.messageService.sendText(voterJid, text, {
-          timeoutMs: Number(process.env.SEND_TIMEOUT_MS || 25_000),
+          timeoutMs: getSendTimeoutMs(),
         });
       } else {
         await this.sock.sendMessage(voterJid, { text });

--- a/src/routes/instances.ts
+++ b/src/routes/instances.ts
@@ -10,7 +10,13 @@ import {
   saveInstancesIndex,
   type Instance,
 } from '../instanceManager.js';
-import { allowSend, sendWithTimeout, waitForAck, normalizeToE164BR } from '../utils.js';
+import {
+  allowSend,
+  sendWithTimeout,
+  waitForAck,
+  normalizeToE164BR,
+  getSendTimeoutMs,
+} from '../utils.js';
 
 const router = Router();
 
@@ -414,7 +420,7 @@ router.post(
     }
 
     const content = message.trim();
-    const timeoutMs = Number(process.env.SEND_TIMEOUT_MS || 25_000);
+    const timeoutMs = getSendTimeoutMs();
     const sent = (inst.context?.messageService
       ? await inst.context.messageService.sendText(normalized, content, { timeoutMs })
       : await sendWithTimeout(inst, normalized, { text: content })) as any;


### PR DESCRIPTION
## Summary
- add a shared `getSendTimeoutMs` helper so every send flow reads the timeout from the environment with the same fallback
- update the HTTP routes, message service, and poll feedback sender to use the shared helper
- clarify in the README that `SEND_TIMEOUT_MS` affects both the API routes and the `MessageService`

## Testing
- npm run build
- npx tsx -e "import { getSendTimeoutMs } from './src/utils.ts'; console.log(getSendTimeoutMs());"
- SEND_TIMEOUT_MS=1234 npx tsx -e "import { getSendTimeoutMs } from './src/utils.ts'; console.log(getSendTimeoutMs());"
- SEND_TIMEOUT_MS=10 npx tsx -e "import { sendWithTimeout } from './src/utils.ts'; const run=async()=>{ const start=Date.now(); const inst:any={sock:{sendMessage(){return new Promise(()=>{});}}}; try { await sendWithTimeout(inst,'jid',{text:'a'}); } catch (err) { console.log(Date.now()-start); } }; run();"

------
https://chatgpt.com/codex/tasks/task_e_68dc397677e88332a3d78acdb6df7e05