### PR TITLE
Implement TTL-based cleanup for message status tracking

### DIFF
--- a/src/instanceManager.ts
+++ b/src/instanceManager.ts
@@ -71,6 +71,8 @@ export interface Instance {
   metadata: InstanceMetadata;
   metrics: InstanceMetrics;
   statusMap: Map<string, AckStatusCode>;
+  statusTimestamps: Map<string, number>;
+  statusCleanupTimer: NodeJS.Timeout | null;
   ackWaiters: Map<string, AckWaiter>;
   rateWindow: number[];
   ackSentAt: Map<string, number>;
@@ -141,6 +143,8 @@ async function loadInstances(): Promise<void> {
         metadata,
         metrics: createEmptyMetrics(),
         statusMap: new Map(),
+        statusTimestamps: new Map(),
+        statusCleanupTimer: null,
         ackWaiters: new Map(),
         rateWindow: [],
         ackSentAt: new Map(),
@@ -185,6 +189,8 @@ async function createInstance(id: string, name: string, meta?: Partial<InstanceM
     metadata: createMetadata(meta),
     metrics: createEmptyMetrics(),
     statusMap: new Map(),
+    statusTimestamps: new Map(),
+    statusCleanupTimer: null,
     ackWaiters: new Map(),
     rateWindow: [],
     ackSentAt: new Map(),


### PR DESCRIPTION
## Summary
- define final WhatsApp status codes and configurable TTL/sweep intervals for status tracking
- prune message status entries when reaching terminal states or stalling past the TTL, recording final metrics snapshots
- manage cleanup timer lifecycle in the instance manager to avoid leaks during shutdown

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc39693c28833280566707d841cb75