### PR TITLE
Ensure live status counters stay in sync

### DIFF
--- a/src/instanceManager.ts
+++ b/src/instanceManager.ts
@@ -71,6 +71,7 @@ export interface Instance {
   metadata: InstanceMetadata;
   metrics: InstanceMetrics;
   statusMap: Map<string, AckStatusCode>;
+  statusHistory: Map<string, AckStatusCode>;
   ackWaiters: Map<string, AckWaiter>;
   rateWindow: number[];
   ackSentAt: Map<string, number>;
@@ -141,6 +142,7 @@ async function loadInstances(): Promise<void> {
         metadata,
         metrics: createEmptyMetrics(),
         statusMap: new Map(),
+        statusHistory: new Map(),
         ackWaiters: new Map(),
         rateWindow: [],
         ackSentAt: new Map(),
@@ -185,6 +187,7 @@ async function createInstance(id: string, name: string, meta?: Partial<InstanceM
     metadata: createMetadata(meta),
     metrics: createEmptyMetrics(),
     statusMap: new Map(),
+    statusHistory: new Map(),
     ackWaiters: new Map(),
     rateWindow: [],
     ackSentAt: new Map(),

--- a/src/routes/instances.ts
+++ b/src/routes/instances.ts
@@ -301,8 +301,11 @@ router.get('/:iid/status', (req, res) => {
     res.status(400).json({ error: 'id obrigatório' });
     return;
   }
-  const status = inst.statusMap.get(id) ?? null;
-  res.json({ id, status });
+  const activeStatus = inst.statusMap.get(id);
+  const historicalStatus = inst.statusHistory.get(id) ?? null;
+  const status = activeStatus ?? historicalStatus ?? null;
+  const final = activeStatus == null && historicalStatus != null;
+  res.json({ id, status, final });
 });
 
 router.get(

--- a/src/routes/instances.ts
+++ b/src/routes/instances.ts
@@ -10,7 +10,13 @@ import {
   saveInstancesIndex,
   type Instance,
 } from '../instanceManager.js';
-import { allowSend, sendWithTimeout, waitForAck, normalizeToE164BR } from '../utils.js';
+import {
+  allowSend,
+  sendWithTimeout,
+  waitForAck,
+  normalizeToE164BR,
+  summarizeStatuses,
+} from '../utils.js';
 
 const router = Router();
 
@@ -514,6 +520,8 @@ router.post(
 
 function serializeInstance(inst: Instance) {
   const connected = Boolean(inst.sock && inst.sock.user);
+  const statusSummary = summarizeStatuses(inst);
+
   return {
     id: inst.id,
     name: inst.name,
@@ -528,7 +536,13 @@ function serializeInstance(inst: Instance) {
     counters: {
       sent: inst.metrics.sent,
       byType: { ...inst.metrics.sent_by_type },
-      statusCounts: { ...inst.metrics.status_counts },
+      statusCounts: { ...statusSummary.counts },
+      pending: statusSummary.pending,
+      serverAck: statusSummary.serverAck,
+      delivered: statusSummary.delivered,
+      read: statusSummary.read,
+      played: statusSummary.played,
+      failed: statusSummary.failed,
     },
     last: { ...inst.metrics.last },
     rate: {

--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -150,9 +150,21 @@ export async function startWhatsAppInstance(inst: Instance): Promise<Instance> {
       const messageId = update.key?.id;
       const status = update.update?.status;
       if (messageId && status != null) {
+        const prevStatus = inst.statusMap.get(messageId);
+        const prevKey = prevStatus == null ? null : String(prevStatus);
+        const nextKey = String(status);
+
+        if (prevKey && prevKey !== nextKey) {
+          const prevCount = inst.metrics.status_counts[prevKey] || 0;
+          inst.metrics.status_counts[prevKey] = Math.max(prevCount - 1, 0);
+        }
+
+        if (prevKey !== nextKey) {
+          inst.metrics.status_counts[nextKey] =
+            (inst.metrics.status_counts[nextKey] || 0) + 1;
+        }
+
         inst.statusMap.set(messageId, status);
-        inst.metrics.status_counts[String(status)] =
-          (inst.metrics.status_counts[String(status)] || 0) + 1;
         inst.metrics.last.lastStatusId = messageId;
         inst.metrics.last.lastStatusCode = status;
 


### PR DESCRIPTION
## Summary
- update WhatsApp message status handling to keep previous and new counters balanced
- derive metrics snapshots and serialized counters directly from the current status map for consistent KPIs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc3953d2988332855b67e7a8329ed5