### PR TITLE
Add broker mode with HTTP event queue

### DIFF
--- a/src/broker/eventStore.ts
+++ b/src/broker/eventStore.ts
@@ -1,0 +1,140 @@
+import crypto from 'node:crypto';
+
+export type BrokerEventDirection = 'inbound' | 'outbound' | 'system';
+
+export interface BrokerEventPayload {
+  [key: string]: unknown;
+}
+
+export interface BrokerEvent {
+  id: string;
+  sequence: number;
+  instanceId: string;
+  direction: BrokerEventDirection;
+  type: string;
+  payload: BrokerEventPayload;
+  createdAt: number;
+  acknowledged: boolean;
+}
+
+export interface BrokerEventListOptions {
+  limit?: number;
+  after?: string | null;
+  instanceId?: string | null;
+  type?: string | null;
+  direction?: BrokerEventDirection | null;
+}
+
+export interface BrokerEventAckResult {
+  acknowledged: string[];
+  missing: string[];
+}
+
+interface EventRecord extends BrokerEvent {}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+const RETAINED_ACKED_EVENTS = 500;
+
+export class BrokerEventStore {
+  private sequence = 0;
+  private readonly events: EventRecord[] = [];
+  private readonly index = new Map<string, EventRecord>();
+  private lastAckAt: number | null = null;
+
+  enqueue(
+    event: Omit<BrokerEvent, 'id' | 'sequence' | 'createdAt' | 'acknowledged'> & {
+      createdAt?: number;
+    },
+  ): BrokerEvent {
+    const id = crypto.randomUUID();
+    const createdAt = event.createdAt ?? Date.now();
+    const record: EventRecord = {
+      ...event,
+      id,
+      createdAt,
+      sequence: ++this.sequence,
+      acknowledged: false,
+    };
+    this.events.push(record);
+    this.index.set(record.id, record);
+    this.pruneAcked();
+    return { ...record };
+  }
+
+  list(options: BrokerEventListOptions = {}): BrokerEvent[] {
+    const limitRaw = Number(options.limit);
+    const limit = Number.isFinite(limitRaw)
+      ? Math.max(1, Math.min(Math.floor(limitRaw), MAX_LIMIT))
+      : DEFAULT_LIMIT;
+
+    let afterSeq = 0;
+    if (options.after) {
+      const cursor = this.index.get(options.after);
+      if (cursor) afterSeq = cursor.sequence;
+    }
+
+    const filtered = this.events.filter((event) => {
+      if (event.acknowledged) return false;
+      if (event.sequence <= afterSeq) return false;
+      if (options.instanceId && event.instanceId !== options.instanceId) return false;
+      if (options.type && event.type !== options.type) return false;
+      if (options.direction && event.direction !== options.direction) return false;
+      return true;
+    });
+
+    return filtered.slice(0, limit).map((event) => ({ ...event }));
+  }
+
+  ack(ids: string[]): BrokerEventAckResult {
+    const acknowledged: string[] = [];
+    const missing: string[] = [];
+    const now = Date.now();
+
+    for (const id of ids) {
+      const record = this.index.get(id);
+      if (!record) {
+        missing.push(id);
+        continue;
+      }
+      if (!record.acknowledged) {
+        record.acknowledged = true;
+        acknowledged.push(id);
+      }
+    }
+
+    if (acknowledged.length) {
+      this.lastAckAt = now;
+    }
+
+    this.pruneAcked();
+
+    return { acknowledged, missing };
+  }
+
+  metrics(): { pending: number; total: number; lastEventAt: number | null; lastAckAt: number | null } {
+    const total = this.events.length;
+    const pending = this.events.reduce((acc, event) => (event.acknowledged ? acc : acc + 1), 0);
+    const lastEventAt = total ? this.events[this.events.length - 1].createdAt : null;
+    return { pending, total, lastEventAt, lastAckAt: this.lastAckAt };
+  }
+
+  private pruneAcked(): void {
+    const acked = this.events.filter((event) => event.acknowledged);
+    if (acked.length <= RETAINED_ACKED_EVENTS) return;
+    const toRemove = acked.length - RETAINED_ACKED_EVENTS;
+    let removed = 0;
+    for (let i = 0; i < this.events.length && removed < toRemove; i += 1) {
+      const event = this.events[i];
+      if (!event.acknowledged) continue;
+      this.index.delete(event.id);
+      this.events.splice(i, 1);
+      removed += 1;
+      i -= 1;
+    }
+  }
+}
+
+export const brokerEventStore = new BrokerEventStore();
+
+export default brokerEventStore;

--- a/src/routes/broker.ts
+++ b/src/routes/broker.ts
@@ -1,0 +1,232 @@
+import { Router, type NextFunction, type Request, type Response } from 'express';
+import crypto from 'node:crypto';
+import {
+  BROKER_INSTANCE_ID,
+  ensureInstance,
+  ensureInstanceStarted,
+  getInstance,
+  removeInstance,
+} from '../instanceManager.js';
+import { brokerEventStore } from '../broker/eventStore.js';
+import {
+  allowSend,
+  getSendTimeoutMs,
+  normalizeToE164BR,
+  sendWithTimeout,
+  waitForAck,
+} from '../utils.js';
+
+const router = Router();
+
+type AsyncHandler = (req: Request, res: Response, next: NextFunction) => Promise<void>;
+const asyncHandler = (fn: AsyncHandler) =>
+  (req: Request, res: Response, next: NextFunction) =>
+    Promise.resolve(fn(req, res, next)).catch(next);
+
+const API_KEYS = String(process.env.API_KEY || 'change-me')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+function safeEquals(a: unknown, b: unknown): boolean {
+  const A = Buffer.from(String(a ?? ''));
+  const B = Buffer.from(String(b ?? ''));
+  if (A.length !== B.length) return false;
+  return crypto.timingSafeEqual(A, B);
+}
+
+function isAuthorized(req: Request): boolean {
+  const key = req.header('x-api-key') || '';
+  return API_KEYS.some((k) => safeEquals(k, key));
+}
+
+function auth(req: Request, res: Response, next: NextFunction): void {
+  if (!isAuthorized(req)) {
+    res.status(401).json({ error: 'unauthorized' });
+    return;
+  }
+  next();
+}
+
+router.use(auth);
+
+function resolveInstanceId(req: Request): string {
+  const bodyId = typeof (req.body as any)?.instanceId === 'string' ? (req.body as any).instanceId : null;
+  const queryId = typeof req.query.instanceId === 'string' ? req.query.instanceId : null;
+  return bodyId || queryId || BROKER_INSTANCE_ID;
+}
+
+router.get(
+  '/events',
+  asyncHandler(async (req, res) => {
+    const events = brokerEventStore.list({
+      limit: req.query.limit ? Number(req.query.limit) : undefined,
+      after: typeof req.query.after === 'string' ? req.query.after : undefined,
+      instanceId: typeof req.query.instanceId === 'string' ? req.query.instanceId : undefined,
+      type: typeof req.query.type === 'string' ? req.query.type : undefined,
+      direction:
+        req.query.direction === 'inbound' || req.query.direction === 'outbound' || req.query.direction === 'system'
+          ? req.query.direction
+          : undefined,
+    });
+
+    res.json({ events, nextCursor: events.length ? events[events.length - 1].id : null });
+  }),
+);
+
+router.post(
+  '/events/ack',
+  asyncHandler(async (req, res) => {
+    const ids = Array.isArray((req.body as any)?.ids)
+      ? ((req.body as any).ids as unknown[]).map((id) => String(id)).filter(Boolean)
+      : [];
+    if (!ids.length) {
+      res.status(400).json({ error: 'ids_required' });
+      return;
+    }
+    const result = brokerEventStore.ack(ids);
+    res.json(result);
+  }),
+);
+
+router.post(
+  '/messages',
+  asyncHandler(async (req, res) => {
+    const body = (req.body || {}) as {
+      instanceId?: string;
+      to?: string;
+      text?: string;
+      waitAckMs?: number;
+      timeoutMs?: number;
+      skipNormalize?: boolean;
+    };
+
+    const instanceId = body.instanceId || resolveInstanceId(req);
+    const inst = await ensureInstanceStarted(instanceId, { name: instanceId });
+    if (!inst.sock) {
+      res.status(503).json({ error: 'socket_unavailable' });
+      return;
+    }
+
+    if (!allowSend(inst)) {
+      res.status(429).json({ error: 'rate_limit_exceeded' });
+      return;
+    }
+
+    const rawTo = body.to || '';
+    const normalized = body.skipNormalize ? rawTo : normalizeToE164BR(rawTo);
+    if (!normalized) {
+      res.status(400).json({ error: 'invalid_destination' });
+      return;
+    }
+
+    const text = typeof body.text === 'string' ? body.text.trim() : '';
+    if (!text) {
+      res.status(400).json({ error: 'text_required' });
+      return;
+    }
+
+    if (!inst.sock.onWhatsApp) {
+      res.status(503).json({ error: 'socket_capability_unavailable' });
+      return;
+    }
+
+    const check = await inst.sock.onWhatsApp(normalized);
+    const entry = Array.isArray(check) ? check[0] : null;
+    if (!entry || !entry.exists) {
+      res.status(404).json({ error: 'whatsapp_not_found' });
+      return;
+    }
+
+    const timeoutMs = Number.isFinite(body.timeoutMs) && Number(body.timeoutMs) > 0 ? Number(body.timeoutMs) : getSendTimeoutMs();
+
+    const message = inst.context?.messageService
+      ? await inst.context.messageService.sendText(normalized, text, { timeoutMs })
+      : ((await sendWithTimeout(inst, normalized, { text })) as any);
+
+    inst.metrics.sent += 1;
+    inst.metrics.sent_by_type.text += 1;
+    inst.metrics.last.sentId = message.key?.id ?? null;
+    if (message.key?.id) {
+      inst.ackSentAt.set(message.key.id, Date.now());
+    }
+
+    let ackStatus: number | null = null;
+    if (body.waitAckMs && message.key?.id) {
+      ackStatus = await waitForAck(inst, message.key.id, body.waitAckMs);
+    }
+
+    res.status(201).json({
+      id: message.key?.id ?? null,
+      ack: ackStatus,
+      timestamp: message.messageTimestamp ?? null,
+    });
+  }),
+);
+
+router.post(
+  '/session/connect',
+  asyncHandler(async (req, res) => {
+    const body = (req.body || {}) as { instanceId?: string; name?: string };
+    const instanceId = body.instanceId || resolveInstanceId(req);
+    const name = typeof body.name === 'string' && body.name.trim() ? body.name.trim() : instanceId;
+
+    const inst = await ensureInstanceStarted(instanceId, { name });
+
+    res.json({
+      id: inst.id,
+      name: inst.name,
+      connected: Boolean(inst.sock?.user),
+      user: inst.sock?.user ?? null,
+      qr: inst.lastQR ?? null,
+    });
+  }),
+);
+
+router.post(
+  '/session/logout',
+  asyncHandler(async (req, res) => {
+    const body = (req.body || {}) as { instanceId?: string; wipe?: boolean };
+    const instanceId = body.instanceId || resolveInstanceId(req);
+    const inst = getInstance(instanceId);
+    if (!inst) {
+      res.status(404).json({ error: 'instance_not_found' });
+      return;
+    }
+
+    await removeInstance(instanceId, { logout: true, removeDir: Boolean(body.wipe) });
+
+    if (body.wipe) {
+      res.json({ id: instanceId, removed: true });
+    } else {
+      await ensureInstance(instanceId, { name: inst.name });
+      res.json({ id: instanceId, removed: false });
+    }
+  }),
+);
+
+router.get(
+  '/session/status',
+  asyncHandler(async (req, res) => {
+    const instanceId = resolveInstanceId(req);
+    const inst = getInstance(instanceId);
+    if (!inst) {
+      res.status(404).json({ error: 'instance_not_found' });
+      return;
+    }
+
+    res.json({
+      id: inst.id,
+      name: inst.name,
+      connected: Boolean(inst.sock?.user),
+      user: inst.sock?.user ?? null,
+      qr: inst.lastQR ?? null,
+      metrics: {
+        sent: inst.metrics.sent,
+        rateWindow: inst.rateWindow.length,
+      },
+    });
+  }),
+);
+
+export default router;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,19 +73,36 @@ export function recordMetricsSnapshot(inst: Instance, force = false): void {
   if (!inst.metrics.timeline) inst.metrics.timeline = [];
   const now = Date.now();
   const last = inst.metrics.timeline[inst.metrics.timeline.length - 1];
-  const statusCounts = inst.metrics.status_counts || {};
-  const pending = statusCounts['1'] || 0;
-  const serverAck = statusCounts['2'] || 0;
-  const delivered = statusCounts['3'] || 0;
-  const read = statusCounts['4'] || 0;
-  const played = statusCounts['5'] || 0;
-  const failed = Object.entries(statusCounts).reduce((acc, [code, value]) => {
-    const numericCode = Number(code);
-    if (Number.isFinite(numericCode) && numericCode >= 6) {
-      return acc + (Number(value) || 0);
+
+  let pending = 0;
+  let serverAck = 0;
+  let delivered = 0;
+  let read = 0;
+  let played = 0;
+  let failed = 0;
+
+  for (const status of inst.statusMap.values()) {
+    switch (status) {
+      case 1:
+        pending += 1;
+        break;
+      case 2:
+        serverAck += 1;
+        break;
+      case 3:
+        delivered += 1;
+        break;
+      case 4:
+        read += 1;
+        break;
+      case 5:
+        played += 1;
+        break;
+      default:
+        if (status >= 6) failed += 1;
+        break;
     }
-    return acc;
-  }, 0);
+  }
 
   if (last && now - last.ts < METRICS_TIMELINE_MIN_INTERVAL_MS) {
     last.sent = inst.metrics.sent;


### PR DESCRIPTION
## Summary
- introduce an in-memory broker event store and new `/broker` HTTP routes to expose queues, messaging, and session controls
- add broker-mode toggles across the server bootstrap, instance management, and documentation so the dashboard remains available in legacy mode
- record queue events from message and poll services and tighten live metrics calculations for message acknowledgements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc31ee471c833283164dc142441429