### PR TITLE
Fix Baileys socket import usage

### DIFF
--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -1,8 +1,8 @@
 import pino from 'pino';
 import {
   DisconnectReason,
-  default as makeWASocket,
   fetchLatestBaileysVersion,
+  makeWASocket,
   useMultiFileAuthState,
 } from '@whiskeysockets/baileys';
 import { recordMetricsSnapshot } from './utils.js';


### PR DESCRIPTION
## Summary
- update the WhatsApp bootstrap import to use the named makeWASocket export from Baileys

## Testing
- npm run build
- npm start (manually verified POST /instances succeeds)


------
https://chatgpt.com/codex/tasks/task_e_68dc3fe0c1648332ac1184daacd69abc