### PR TITLE
Allow blob image sources in CSP

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -45,6 +45,10 @@ if (BROKER_FLAG) {
             'https://cdn.tailwindcss.com',
             'https://cdn.jsdelivr.net',
           ],
+          'img-src': [
+            ...(defaultCsp['img-src'] ?? []),
+            'blob:',
+          ],
         },
       },
     }),


### PR DESCRIPTION
## Summary
- merge the default Helmet CSP directives with an explicit `img-src` entry that permits `blob:` URLs
- retain the existing script source whitelist for Tailwind and jsDelivr

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc5beb3ff88332b40d950896dc298c