### PR TITLE
Fix JID usage when sending messages

### DIFF
--- a/src/routes/instances.ts
+++ b/src/routes/instances.ts
@@ -421,9 +421,11 @@ router.post(
 
     const content = message.trim();
     const timeoutMs = getSendTimeoutMs();
+    const targetJid = entry?.jid ?? `${normalized}@s.whatsapp.net`;
+
     const sent = (inst.context?.messageService
-      ? await inst.context.messageService.sendText(normalized, content, { timeoutMs })
-      : await sendWithTimeout(inst, normalized, { text: content })) as any;
+      ? await inst.context.messageService.sendText(targetJid, content, { timeoutMs })
+      : await sendWithTimeout(inst, targetJid, { text: content })) as any;
     inst.metrics.sent += 1;
     inst.metrics.sent_by_type.text += 1;
     inst.metrics.last.sentId = sent.key.id ?? null;
@@ -499,7 +501,9 @@ router.post(
       ? Math.max(1, Math.min(Math.floor(selectableRaw), sanitized.length))
       : 1;
 
-    const sent = (await pollService.sendPoll(normalized, question.trim(), sanitized, {
+    const targetJid = entry?.jid ?? `${normalized}@s.whatsapp.net`;
+
+    const sent = (await pollService.sendPoll(targetJid, question.trim(), sanitized, {
       selectableCount: selectable,
     })) as any;
     inst.metrics.sent += 1;


### PR DESCRIPTION
## Summary
- ensure send-text and send-poll routes build a target JID from the onWhatsApp lookup
- reuse the resolved target JID for text message fallback and poll service calls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3d5a2f7c88329a86b90e2b62e6acb