### PR TITLE
Refactor Express request typings in webhook example

### DIFF
--- a/src/examples/pollWebhookServer.ts
+++ b/src/examples/pollWebhookServer.ts
@@ -1,9 +1,13 @@
 import 'dotenv/config';
 import crypto from 'node:crypto';
-import express, { type NextFunction, type Request, type Response } from 'express';
+import express, {
+  type NextFunction,
+  type Request as ExpressRequest,
+  type Response,
+} from 'express';
 import pino from 'pino';
 
-interface RequestWithRawBody extends Request {
+interface RequestWithRawBody extends ExpressRequest {
   rawBody?: Buffer;
 }
 
@@ -47,7 +51,7 @@ app.use(
   }),
 );
 
-app.use((req: Request, _res: Response, next: NextFunction) => {
+app.use((req: ExpressRequest, _res: Response, next: NextFunction) => {
   (req as RequestWithRawBody).rawBody ??= Buffer.from('');
   next();
 });


### PR DESCRIPTION
## Summary
- alias the Express Request type to avoid relying on the global declaration in the webhook example
- update middleware signatures to use the new ExpressRequest alias

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e40c118c908329ae0634bc5c1fe32e