### PR TITLE
Handle undocumented Baileys phone number share event

### DIFF
--- a/src/instanceManager.ts
+++ b/src/instanceManager.ts
@@ -120,6 +120,8 @@ function onInstanceEvent(listener: (event: InstanceEventPayload) => void): () =>
   return () => {
     instanceEventEmitter.off('event', listener);
   };
+}
+
 const MAX_NOTE_REVISIONS = 20;
 const NOTE_MAX_LENGTH = 280;
 

--- a/src/lidMappingStore.ts
+++ b/src/lidMappingStore.ts
@@ -1,12 +1,10 @@
 import type Long from 'long';
-import type { JidServer } from '@whiskeysockets/baileys';
-import { jidDecode, jidEncode, isLidUser } from '@whiskeysockets/baileys/lib/WABinary/jid-utils.js';
 import {
   jidDecode,
   jidEncode,
   isLidUser,
+  type JidServer,
 } from '@whiskeysockets/baileys/lib/WABinary/jid-utils.js';
-import type { JidServer } from '@whiskeysockets/baileys/lib/WABinary/jid-utils.js';
 
 const S_WHATSAPP_NET_SERVER: JidServer = 's.whatsapp.net';
 const LID_SERVER: JidServer = 'lid';

--- a/src/routes/instances.ts
+++ b/src/routes/instances.ts
@@ -73,6 +73,8 @@ function isAuthorized(req: Request): boolean {
   const key = extractApiKey(req);
   if (!key) return false;
   return API_KEYS.some((k) => safeEquals(k, key));
+}
+
 function resolveApiKeyMatch(value: string): string | null {
   for (const candidate of API_KEYS) {
     if (safeEquals(candidate, value)) return candidate;
@@ -368,6 +370,8 @@ function buildMetricsPayload(inst: Instance, range: MetricsRange) {
     },
     aggregates,
   };
+}
+
 function connectionUpdatedAtIso(inst: Instance | undefined): string | null {
   return toIsoFromMs(inst?.connectionUpdatedAt ?? null);
 }
@@ -1122,13 +1126,17 @@ function buildCsvPayload(inst: Instance, range: MetricsRange): string {
   const payload = buildMetricsPayload(inst, range);
   const lines: string[] = [];
   const generatedAt = new Date().toISOString();
+  const totalSent =
+    payload.counters && 'sent' in payload.counters && typeof payload.counters.sent === 'number'
+      ? payload.counters.sent
+      : '';
   lines.push(['meta', 'instanceId', payload.id].map(csvEscape).join(','));
   lines.push(['meta', 'generatedAt', generatedAt].map(csvEscape).join(','));
   lines.push(['meta', 'range.requested.from', payload.range?.requested?.from ?? ''].map(csvEscape).join(','));
   lines.push(['meta', 'range.requested.to', payload.range?.requested?.to ?? ''].map(csvEscape).join(','));
   lines.push(['meta', 'range.effective.from', payload.range?.effective?.from ?? ''].map(csvEscape).join(','));
   lines.push(['meta', 'range.effective.to', payload.range?.effective?.to ?? ''].map(csvEscape).join(','));
-  lines.push(['meta', 'sent.total', payload.counters?.sent ?? ''].map(csvEscape).join(','));
+  lines.push(['meta', 'sent.total', totalSent].map(csvEscape).join(','));
   lines.push(['meta', 'sent.delta', payload.range?.summary?.deltas?.sent ?? ''].map(csvEscape).join(','));
   lines.push(['meta', 'delivery.pending', payload.delivery?.pending ?? ''].map(csvEscape).join(','));
   lines.push(['meta', 'delivery.serverAck', payload.delivery?.serverAck ?? ''].map(csvEscape).join(','));

--- a/src/whatsapp.ts
+++ b/src/whatsapp.ts
@@ -7,8 +7,6 @@ import {
 } from '@whiskeysockets/baileys';
 import type { BaileysEventMap } from '@whiskeysockets/baileys';
 import { recordMetricsSnapshot, resolveAckWaiters } from './utils.js';
-import { type Instance, resetInstanceSession } from './instanceManager.js';
-import { recordMetricsSnapshot } from './utils.js';
 import {
   type Instance,
   resetInstanceSession,
@@ -23,7 +21,18 @@ import { filterClientMessages } from './baileys/messageUtils.js';
 
 const logger = pino({ level: process.env.LOG_LEVEL || 'info' });
 const PHONE_NUMBER_SHARE_EVENT = 'chats.phoneNumberShare' as const;
-type PhoneNumberSharePayload = BaileysEventMap[typeof PHONE_NUMBER_SHARE_EVENT];
+type PhoneNumberSharePayload = {
+  jid?: unknown;
+  lid?: unknown;
+} | null | undefined;
+function extractPhoneNumberShare(payload: PhoneNumberSharePayload): {
+  jid: string | null;
+  lid: string | null;
+} {
+  const jid = typeof payload?.jid === 'string' && payload.jid.trim() ? payload.jid : null;
+  const lid = typeof payload?.lid === 'string' && payload.lid.trim() ? payload.lid : null;
+  return { jid, lid };
+}
 
 const RECONNECT_MIN_DELAY_MS = 1_000;
 const RECONNECT_MAX_DELAY_MS = 30_000;
@@ -280,10 +289,11 @@ export async function startWhatsAppInstance(inst: Instance): Promise<Instance> {
   inst.context = null;
 
   sock.ev.on('creds.update', saveCreds);
-  sock.ev.on(PHONE_NUMBER_SHARE_EVENT, (payload: PhoneNumberSharePayload) => {
-    const added = inst.lidMapping.rememberMapping(payload?.jid, payload?.lid);
+  sock.ev.on(PHONE_NUMBER_SHARE_EVENT as unknown as keyof BaileysEventMap, (payload: unknown) => {
+    const { jid, lid } = extractPhoneNumberShare(payload as PhoneNumberSharePayload);
+    const added = inst.lidMapping.rememberMapping(jid, lid);
     if (added) {
-      logger.debug({ iid: inst.id, jid: payload?.jid, lid: payload?.lid }, 'lidMapping.share');
+      logger.debug({ iid: inst.id, jid, lid }, 'lidMapping.share');
     }
   });
   sock.ev.on('lid-mapping.update' as unknown as keyof BaileysEventMap, (payload: unknown) => {


### PR DESCRIPTION
## Summary
- add a sanitizer for phone number share payloads instead of relying on missing Baileys typings
- subscribe to the phone number share event using a typed cast and log the normalized identifiers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6905072ebeb483298c29bb0d6180b857